### PR TITLE
RFC: Naive benchmarking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,10 +215,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714a157da7991e23d90686b9524b9e12e0407a108647f52e9328f4b3d51ac7f"
 dependencies = [
  "cargo-platform",
- "semver",
+ "semver 0.11.0",
  "semver-parser",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "cast"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -242,6 +263,17 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "bitflags",
+ "textwrap 0.11.0",
+ "unicode-width",
+]
+
+[[package]]
+name = "clap"
 version = "3.0.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "484f17839417b695a6f4a75c20e49820ba0a1d00aa41ebd8ba0e5dfe0fbc3b74"
@@ -254,7 +286,7 @@ dependencies = [
  "os_str_bytes",
  "strsim",
  "termcolor",
- "textwrap",
+ "textwrap 0.14.2",
 ]
 
 [[package]]
@@ -303,12 +335,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+dependencies = [
+ "atty",
+ "cast",
+ "clap 2.34.0",
+ "criterion-plot",
+ "csv",
+ "futures",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch 0.9.5",
  "crossbeam-utils 0.8.5",
 ]
 
@@ -323,7 +404,20 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
- "memoffset",
+ "memoffset 0.5.6",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.5",
+ "lazy_static",
+ "memoffset 0.6.5",
  "scopeguard",
 ]
 
@@ -356,6 +450,28 @@ checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -424,6 +540,12 @@ name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "enum-as-inner"
@@ -622,6 +744,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +924,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,7 +970,8 @@ name = "lila-http"
 version = "0.1.0"
 dependencies = [
  "axum",
- "clap",
+ "clap 3.0.0-rc.8",
+ "criterion",
  "env_logger",
  "futures",
  "log",
@@ -941,6 +1079,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,7 +1142,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829e4b3f52dff046d1824842169dc0a91319f5e923e20a651b4e85697e03feea"
 dependencies = [
- "crossbeam-epoch",
+ "crossbeam-epoch 0.8.2",
  "num_cpus",
 ]
 
@@ -1090,6 +1237,12 @@ name = "once_cell"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
@@ -1202,6 +1355,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "polling"
@@ -1347,6 +1528,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils 0.8.5",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "redis"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,6 +1593,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,6 +1636,15 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.4",
 ]
 
 [[package]]
@@ -1505,6 +1726,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+
+[[package]]
 name = "semver-parser"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,6 +1755,16 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
  "serde",
 ]
 
@@ -1754,6 +1991,15 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
@@ -1786,6 +2032,16 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2041,6 +2297,12 @@ name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,10 @@ serde_with = "1.11.0"
 thiserror = "1.0.30"
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.2", features = ["set-header"] }
+
+[dev-dependencies]
+criterion = { version = "0.3", features = ["async_tokio"] }
+
+[[bench]]
+name = "copy_vs_ref"
+harness = false

--- a/benches/copy_vs_ref.rs
+++ b/benches/copy_vs_ref.rs
@@ -1,0 +1,101 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use lila_http::{
+    arena::{ArenaFull, ArenaId, ArenaShared, ClientData, ClientMe, FullRanking, UserId},
+    repo::Repo,
+};
+use serde::Serialize;
+use serde_json::{json, Value as JsValue};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Serialize)]
+struct ClientStandingRef<'p> {
+    page: u32,
+    players: &'p [JsValue],
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ClientDataRef<'a> {
+    #[serde(flatten)]
+    shared: &'a ArenaShared,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    me: Option<ClientMe>,
+    standing: ClientStandingRef<'a>,
+}
+
+impl<'a> ClientDataRef<'a> {
+    pub fn new<'b>(full: &'b Arc<ArenaFull>, user_id: Option<UserId>) -> ClientDataRef<'b> {
+        let page = 50;
+        ClientDataRef {
+            shared: &full.shared,
+            me: user_id.map(|uid| ClientMe {
+                rank: full.ranking.ranking.get(&uid).cloned(),
+                withdraw: false, // todo!(),
+                game_id: full.ongoing_user_games.get(&uid).cloned(),
+                pause_delay: None,
+            }),
+            standing: ClientStandingRef {
+                page: 1,
+                players: &full.standing[((page - 1) * 10)..(page * 10 - 1)], // TODO: check bounds,
+            },
+        }
+    }
+}
+
+fn no_ref(full: Arc<ArenaFull>, user_id: Option<UserId>) -> ClientData {
+    ClientData::new(full, user_id)
+}
+
+fn with_ref<'a>(full: &'a Arc<ArenaFull>, user_id: Option<UserId>) -> ClientDataRef<'a> {
+    ClientDataRef::new(full, user_id)
+}
+
+fn generate_arena(id: ArenaId) -> ArenaFull {
+    let shared = Arc::new(ArenaShared {
+        nb_players: 15000,
+        duels: JsValue::Null,
+        seconds_to_finish: Some(200000),
+        seconds_to_start: Some(200000),
+        is_started: Some(true),
+        is_finished: Some(false),
+        is_recently_finished: Some(false),
+        featured: Some(JsValue::Null),
+        podium: Some(JsValue::Null),
+        pairings_closed: Some(false),
+        stats: Some(JsValue::Null),
+        team_standing: Some(JsValue::Null),
+        duel_teams: Some(JsValue::Null),
+    });
+    let ongoing_user_games = HashMap::new();
+    let ranking = FullRanking {
+        ranking: HashMap::new(),
+    };
+    let mut standing = Vec::new();
+    let rando: Vec<JsValue> = (1..1000i64).map(|i| json!(i)).collect();
+    for _i in 1..1500 {
+        standing.push(JsValue::Array(rando.clone()));
+    }
+    ArenaFull {
+        id,
+        shared,
+        ongoing_user_games,
+        ranking,
+        standing,
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let id = ArenaId("asdf".into());
+    let user_id = Some(UserId("asdf".into()));
+
+    let full = Arc::new(generate_arena(id));
+    c.bench_function("no ref", |b| {
+        b.iter(|| no_ref(black_box(full.clone()), black_box(user_id.clone())))
+    });
+    c.bench_function("with ref", |b| {
+        b.iter(|| with_ref(black_box(&full), black_box(user_id.clone())))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/copy_vs_ref.rs
+++ b/benches/copy_vs_ref.rs
@@ -4,7 +4,7 @@ use lila_http::{
     repo::Repo,
 };
 use serde::Serialize;
-use serde_json::{json, Value as JsValue};
+use serde_json::{json, to_string, Value as JsValue};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -42,12 +42,12 @@ impl<'a> ClientDataRef<'a> {
     }
 }
 
-fn no_ref(full: Arc<ArenaFull>, user_id: Option<UserId>) -> ClientData {
-    ClientData::new(full, user_id)
+fn no_ref(full: Arc<ArenaFull>, user_id: Option<UserId>) -> String {
+    to_string(&ClientData::new(full, user_id)).unwrap()
 }
 
-fn with_ref<'a>(full: &'a Arc<ArenaFull>, user_id: Option<UserId>) -> ClientDataRef<'a> {
-    ClientDataRef::new(full, user_id)
+fn with_ref(full: &Arc<ArenaFull>, user_id: Option<UserId>) -> String {
+    to_string(&ClientDataRef::new(full, user_id)).unwrap()
 }
 
 fn generate_arena(id: ArenaId) -> ArenaFull {

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -102,8 +102,7 @@ pub struct ClientData {
 }
 
 impl ClientData {
-    pub fn new(full: Arc<ArenaFull>, user_id: Option<UserId>) -> ClientData {
-        let page = 1;
+    pub fn new(page: usize, full: Arc<ArenaFull>, user_id: Option<UserId>) -> ClientData {
         ClientData {
             shared: Arc::clone(&full.shared),
             me: user_id.map(|uid| ClientMe {

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -11,30 +11,30 @@ pub struct ArenaId(pub String);
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ArenaShared {
-    nb_players: u32,
-    duels: JsValue,
+    pub nb_players: u32,
+    pub duels: JsValue,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    seconds_to_finish: Option<u32>,
+    pub seconds_to_finish: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    seconds_to_start: Option<u32>,
+    pub seconds_to_start: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    is_started: Option<bool>,
+    pub is_started: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    is_finished: Option<bool>,
+    pub is_finished: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    is_recently_finished: Option<bool>,
+    pub is_recently_finished: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    featured: Option<JsValue>,
+    pub featured: Option<JsValue>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    podium: Option<JsValue>,
+    pub podium: Option<JsValue>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pairings_closed: Option<bool>,
+    pub pairings_closed: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    stats: Option<JsValue>,
+    pub stats: Option<JsValue>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    team_standing: Option<JsValue>,
+    pub team_standing: Option<JsValue>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    duel_teams: Option<JsValue>,
+    pub duel_teams: Option<JsValue>,
 }
 
 #[derive(Debug, Clone, Deserialize, Eq, PartialEq, Hash)]
@@ -50,17 +50,17 @@ pub struct Rank(usize);
 pub struct ArenaFull {
     pub id: ArenaId,
     #[serde(flatten)]
-    shared: Arc<ArenaShared>,
-    ongoing_user_games: HashMap<UserId, GameId>,
+    pub shared: Arc<ArenaShared>,
+    pub ongoing_user_games: HashMap<UserId, GameId>,
     // this duplicates info gotten from standing, remove
     #[serde_as(as = "FromInto<String>")]
-    ranking: FullRanking,
-    standing: Vec<JsValue>,
+    pub ranking: FullRanking,
+    pub standing: Vec<JsValue>,
 }
 
 #[derive(Debug, Clone)]
-struct FullRanking {
-    ranking: HashMap<UserId, Rank>,
+pub struct FullRanking {
+    pub ranking: HashMap<UserId, Rank>,
 }
 
 impl From<String> for FullRanking {
@@ -79,15 +79,15 @@ impl From<String> for FullRanking {
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct ClientMe {
-    rank: Option<Rank>,
-    withdraw: bool,
-    game_id: Option<GameId>,
-    pause_delay: Option<u32>,
+pub struct ClientMe {
+    pub rank: Option<Rank>,
+    pub withdraw: bool,
+    pub game_id: Option<GameId>,
+    pub pause_delay: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct ClientStanding {
+pub struct ClientStanding {
     page: u32,
     players: Vec<JsValue>,
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,8 +1,9 @@
 use axum::{
-    body, http::StatusCode,
+    body,
+    http::StatusCode,
     response::{IntoResponse, Response},
 };
-use thiserror::{Error as ThisError};
+use thiserror::Error as ThisError;
 
 #[derive(ThisError, Debug)]
 pub enum HttpResponseError {
@@ -17,7 +18,6 @@ impl IntoResponse for HttpResponseError {
                 .status(sc)
                 .body(body::boxed(body::Full::from(sc.to_string())))
                 .unwrap(),
-
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod arena;
+pub mod repo;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,19 +5,18 @@ pub mod opt;
 pub mod redis;
 pub mod repo;
 
+use crate::http::{not_found, HttpResponseError};
 use arena::{ArenaId, ClientData, UserId};
 use axum::{
     extract::{Extension, Path, Query},
     routing::get,
-    Json,
-    AddExtensionLayer, Router,
+    AddExtensionLayer, Json, Router,
 };
 use clap::Parser;
 use opt::Opt;
 use repo::Repo;
 use serde::Deserialize;
 use std::sync::Arc;
-use crate::http::{not_found, HttpResponseError};
 
 #[tokio::main]
 async fn main() {
@@ -74,7 +73,7 @@ async fn arena(
     Extension(repo): Extension<Arc<Repo>>,
 ) -> Result<Json<ClientData>, HttpResponseError> {
     repo.get(id)
-        .map(|full| Json(ClientData::new(full, query.user_id)))
+        .map(|full| Json(ClientData::new(1, full, query.user_id)))
         .ok_or_else(not_found)
 }
 


### PR DESCRIPTION
This may be too early in the process to profile, but I was curious.  This PR is not mergeable as it makes everything public, because I was lazy and didn't want to spend time figuring out the crate stuff.  It also should generate/use an `ArenaFull` that is more indicative of the sort of data we'll actually be using before it's particularly useful to to compare the numbers.  However, on my machine here is what we get:

```rust
no ref                  time:   [424.39 us 425.09 us 425.86 us]
                        change: [+47.133% +47.355% +47.559%] (p = 0.00 < 0.05)
                        Performance has regressed.

with ref                time:   [119.62 us 119.79 us 119.97 us]
                        change: [+146663% +147154% +147625%] (p = 0.00 < 0.05)
                        Performance has regressed.
``` 